### PR TITLE
Do not overwrite kernel version if already given, otherwise use version of running kernel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 modname := shiftfs
 obj-m := $(modname).o
 
-KVERSION := $(shell uname -r)
-KDIR ?= /lib/modules/`uname -r`/build
+KVERSION ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVERSION)/build
 PWD := "$$(pwd)"
 
 ifdef DEBUG


### PR DESCRIPTION
The DKMS machinery of Ubuntu (and I suspect other uses of DKMS), pass the kernel version of the desired kernel to build the module for in the KVERSION make variable. So use that if set, otherwise do the old behavior of building for the version of the running kernel. This allows DKMS to build the module for a version of the kernel that is not currently running. This will be needed for the scenario brought up in #10 where multiple kernels are built for via DKMS.